### PR TITLE
Update Github Actions versions for Node 12 + set-output deprecations

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: lykahb/paths-filter@v2
       id: filter
       with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A breakdown tells reviewer at a glance what the changes are. Does the bulk of th
 ## Example usage
 
 ``` yaml
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: lykahb/paths-filter@v2
   id: filter
   with:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: peter-evans/find-comment@v1
+    - uses: peter-evans/find-comment@v2
       id: find-comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -25,7 +25,7 @@ runs:
         COMMENT_BODY="${COMMENT_BODY//$'\n'/'%0A'}"
         COMMENT_BODY="${COMMENT_BODY//$'\r'/'%0D'}"
         echo "::set-output name=comment_body::$COMMENT_BODY"
-    - uses: peter-evans/create-or-update-comment@v1
+    - uses: peter-evans/create-or-update-comment@v2
       id: create-or-update-comment
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
* Github actions running on Node 12 have recently been deprecated: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
  * This is fixed by using newer versions of other actions, like `actions/checkout@v3`
* Github has also, more recently + more rapidly, deprecated `::set-output` in favour of an environment file: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
  * This was fixed upstream in the peter-evans packages