### PR TITLE
Add configurable threshold for depositing a comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,17 +6,29 @@ inputs:
   diff-stat:
     description: 'The JSON object describing changes. This is the "stat" output of lykahb/paths-filter.'
     required: true
+  minimum-files:
+    description: 'The minimum number of files that must change before a comment is posted'
+    default: 0
+  minimum-lines:
+    description: 'The minimum number of lines of code that must change before a comment is posted'
+    default: 0
 
 runs:
   using: 'composite'
   steps:
-    - uses: peter-evans/find-comment@v2
+    - id: condition
+      shell: bash
+      run: |
+        echo "passed=$(jq 'to_entries | map(.value) | (map(.additionCount + .deletionCount) | ${{ inputs.minimum-lines }} <= add) and (map (.fileCount) | ${{ inputs.minimum-files }} <= add)' <<< '${{ inputs.diff-stat }}')" >> "${GITHUB_OUTPUT}"
+    - if: steps.condition.passed
+      uses: peter-evans/find-comment@v2
       id: find-comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: '<!-- Paths Filter with Diff Stat -->'
-    - id: make-comment-body
+    - if: steps.condition.passed
+      id: make-comment-body
       shell: bash
       run: |
         JQ_FILTER='to_entries | group_by(.key=="other") | flatten | .[] | select (.value.fileCount > 0) | "| \(.key) | \(.value.fileCount) | \(.value.additionCount) | \(.value.deletionCount) |"'
@@ -25,7 +37,8 @@ runs:
         COMMENT_BODY="${COMMENT_BODY//$'\n'/'%0A'}"
         COMMENT_BODY="${COMMENT_BODY//$'\r'/'%0D'}"
         echo "::set-output name=comment_body::$COMMENT_BODY"
-    - uses: peter-evans/create-or-update-comment@v2
+    - if: steps.condition.passed
+      uses: peter-evans/create-or-update-comment@v2
       id: create-or-update-comment
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/action.yml
+++ b/action.yml
@@ -20,14 +20,14 @@ runs:
       shell: bash
       run: |
         echo "passed=$(jq 'to_entries | map(.value) | (map(.additionCount + .deletionCount) | ${{ inputs.minimum-lines }} <= add) and (map (.fileCount) | ${{ inputs.minimum-files }} <= add)' <<< '${{ inputs.diff-stat }}')" >> "${GITHUB_OUTPUT}"
-    - if: steps.condition.passed
+    - if: steps.condition.outputs.passed
       uses: peter-evans/find-comment@v2
       id: find-comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: '<!-- Paths Filter with Diff Stat -->'
-    - if: steps.condition.passed
+    - if: steps.condition.outputs.passed
       id: make-comment-body
       shell: bash
       run: |
@@ -37,7 +37,7 @@ runs:
         COMMENT_BODY="${COMMENT_BODY//$'\n'/'%0A'}"
         COMMENT_BODY="${COMMENT_BODY//$'\r'/'%0D'}"
         echo "::set-output name=comment_body::$COMMENT_BODY"
-    - if: steps.condition.passed
+    - if: steps.condition.outputs.passed
       uses: peter-evans/create-or-update-comment@v2
       id: create-or-update-comment
       with:

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,10 @@ inputs:
     description: 'The JSON object describing changes. This is the "stat" output of lykahb/paths-filter.'
     required: true
   minimum-files:
-    description: 'The minimum number of files that must change before a comment is posted'
+    description: 'There minimum number of files that must change before a comment is posted. If both minimum-files and minimum-lines are set, the conditions for both must be met before a comment is posted.'
     default: 0
   minimum-lines:
-    description: 'The minimum number of lines of code that must change before a comment is posted'
+    description: 'The minimum number of lines of code that must change before a comment is posted. If both minimum-files and minimum-lines are set, the conditions for both must be met before a comment is posted.'
     default: 0
 
 runs:


### PR DESCRIPTION
Sometimes smaller PRs don't benefit from the breakdown, so this adds two new configurable parameters to establish a threshold for reporting stats.